### PR TITLE
Handle nodes that are missing node data

### DIFF
--- a/chef-valkyrie
+++ b/chef-valkyrie
@@ -143,8 +143,13 @@ def getNodeData(node):
     this.logger.error('Could not read node data for %s', node)
     this.logger.error(failure.message)
     raise
-  this.logger.debug('%s node account_id: %s', node, nodeData['ec2']['account_id'])
-  this.logger.debug('%s node instance_id: %s', node, nodeData['ec2']['instance_id'])
+  try:
+    if nodeData is None:
+      this.logger.warning('WTF %s has no nodeData', node)
+    this.logger.debug('%s node account_id: %s', node, nodeData['ec2']['account_id'])
+    this.logger.debug('%s node instance_id: %s', node, nodeData['ec2']['instance_id'])
+  except TypeError:
+    this.logger.debug('%s node has no account_id or instance_id', node)
   return nodeData
 
 
@@ -180,10 +185,15 @@ def verifyNode(node, awsAccountID):
     return True # Keep the grime reaper from deleting this node
 
   try:
+    if nodeData is None:
+      this.logger.critical('node %s has no nodeData', node)
     instanceID = nodeData['ec2']['instance_id']
   except KeyError as failure:
     this.logger.info('Could not read ec2.instance_id key for node %s - we only prune AWS instances, skipping', node)
     return True
+  except TypeError as typeFail:
+    this.logger.warning('Could not get valid data for node %s', node)
+    return False
 
   if awsAccountID != nodeData['ec2']['account_id']:
     this.logger.debug('%s is in account %s, not %s, skipping', node, nodeData['ec2']['account_id'], awsAccountID)


### PR DESCRIPTION
If the node data is missing, this usually means the instance crapped out during the initial assimilation into Chef. We've seen that occasionally with EMR nodes when for some reason, EMR decides to not successfully start the instances, even though the same identical command worked 15 minutes earlier and works again 15 minutes later.

And I know the command is identical, I just uparrowed and hit return.